### PR TITLE
feat: add alternate routing options and restore branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .vite
 .DS_Store
+tsconfig.tsbuildinfo

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useState, useCallback, useEffect } from "react";
-import { BASE_POS, segmentsFromStations, getSegment, type XY } from "./models/network";
+import { BASE_POS, segmentsFromStations, getSegment, type XY, buildEdgesFromPath, findPaths } from "./models/network";
 
 type LineStyle = 'solid' | 'dashed' | 'dotted';
 type LineDef = { id: string; name: string; style: LineStyle; color: string; segments: string[] };
@@ -156,6 +156,8 @@ const CORRIDORS: Corridor[] = [
   { id:'C_MSK_ELI_BLUE', name:'Москва → Махачкала(M6-синий)', color:'#1A73E8', lineIds:['MSK-VLG', 'VLG-ELI-GRZ-MAH-BLUE','VLG-ELI-AST-MAH-BLUE'] },
   { id:'C_EAST_RED', name:'Кавказ → Тольятти(красный)', color:'#F40009', lineIds:['VLG-ELI-CAUC-PURPLE','VLG-ELI-GRZ-MAH','VLG-ELI-AST-MAH','VLG-SRT-UFA'] },
   { id:'C_EAST_SALAD', name:'Москва → Владивосток (салатовый)', color:'#7ED957', lineIds:['MSK-NCH-SALAD','OMSK-NCH-IZH','OMSK-NCH-UFA','OMSK-VVO-SALAD'] },
+  { id:'C_MSK_KRD', name:'Москва → Краснодар (оранжевый)', color:'#CC5500', lineIds:['MSK-RSTDN','RST-KRD'] },
+  { id:'C_MSK_ORSK', name:'Москва → Орск (серый)', color:'#BDBDBD', lineIds:['MSK-ORSK'] },
   { id:'C_SIB_SHORTS', name:'Сибирские ответвления (коричневый)', color:'#8B4513', lineIds:['NSK-GALT','TOM-NOVK','KRS-KYZ','CHT-MAG'] },
   { id:'C_VOLGA_BROWN', name:'Поволжье (коричневый)', color:'#8B4513', lineIds:['YOL-CHB-NNOV-VLA-MSK','MSK-VLA-NNOV-CHB-KZN-ULY-TLT'] },
   { id:'C_SOUTH_GREY', name:'Крым → Владивосток(фиолетовый)', color:'#7E57C2', lineIds:['VLG-RST-PURPLE','RST-MAR-CRIMEA-PINK','RST-KRD-PURPLE','KRD-CRIMEA-PINK','SRT-VRN-RST','OMSK-VVO-GREY','OMSK-VLG-GREY','OMSK-NCH-IZH-GRAY'] }
@@ -197,6 +199,21 @@ export default function MetroBranches(){
   const pos = BASE_POS;
   const svgRef = useRef<SVGSVGElement>(null);
   const labels = useMemo(()=>placeLabels(stations,pos,13,scale),[scale]);
+
+  const [startStation, setStartStation] = useState<string>("");
+  const [endStation, setEndStation] = useState<string>("");
+  const [pathIndex, setPathIndex] = useState(0);
+
+  const pathOptions = useMemo(() => {
+    if(!startStation || !endStation) return [] as Array<{path:string[]; length:number}>;
+    return findPaths(startStation, endStation, 5);
+  }, [startStation, endStation]);
+
+  useEffect(() => { setPathIndex(0); }, [startStation, endStation]);
+
+  const pathInfo = pathOptions[pathIndex] ?? { path: [], length: 0 };
+
+  const pathEdges = useMemo(() => buildEdgesFromPath(pathInfo.path), [pathInfo.path]);
 
   const containerWidth=1200, containerHeight=800;
 
@@ -244,6 +261,30 @@ export default function MetroBranches(){
 
       <div className="flex">
         <div className="w-80 bg-white border-r p-3 h-screen overflow-y-auto">
+          <div className="mb-4">
+            <h3 className="font-bold text-base mb-2 text-gray-800">Маршрут</h3>
+            <div className="space-y-2 text-sm">
+              <select value={startStation} onChange={e=>setStartStation(e.target.value)} className="w-full border p-1 rounded">
+                <option value="">Начальная станция</option>
+                {stations.map(s=>(<option key={s} value={s}>{s}</option>))}
+              </select>
+              <select value={endStation} onChange={e=>setEndStation(e.target.value)} className="w-full border p-1 rounded">
+                <option value="">Конечная станция</option>
+                {stations.map(s=>(<option key={s} value={s}>{s}</option>))}
+              </select>
+              {pathOptions.length>1 && (
+                <select value={pathIndex} onChange={e=>setPathIndex(Number(e.target.value))} className="w-full border p-1 rounded">
+                  {pathOptions.map((p,i)=>(<option key={i} value={i}>Вариант {i+1} ({Math.round(p.length)})</option>))}
+                </select>
+              )}
+              {pathInfo.path.length>1 && (
+                <div className="pt-1 space-y-1">
+                  <div>Протяжённость: {Math.round(pathInfo.length)}</div>
+                  <div className="text-xs text-gray-600 break-words">{pathInfo.path.join(' → ')}</div>
+                </div>
+              )}
+            </div>
+          </div>
           <h3 className="font-bold text-base mb-2 text-gray-800">Коридоры</h3>
           <LegendCorridors CORRIDORS={CORRIDORS} LINES={LINES} visible={visible} toggleCorridor={toggleCorridor} soloCorridor={soloCorridor} toggleLine={toggleLine} />
           <div className="mt-4 border-t pt-3 text-xs">
@@ -275,6 +316,11 @@ export default function MetroBranches(){
             <g transform={`translate(${translateX}, ${translateY}) scale(${scale})`}>
               <Grid />
               <RouteLines lines={activeLines} pos={pos} allLines={LINES} />
+              {pathEdges.map((e,i)=>{
+                const a=pos[e.a], b=pos[e.b];
+                if(!a||!b) return null;
+                return <line key={`path_${i}`} x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="#000" strokeWidth={10} strokeLinecap="round" />;
+              })}
               <StationsAndLabels stations={stations} pos={pos} labels={labels} />
             </g>
           </svg>


### PR DESCRIPTION
## Summary
- compute multiple route options with new `findPaths` helper
- show selectable path variants with station list and distance
- add corridors for Moscow–Krasnodar and Moscow–Orsk branches

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4ed89d13083219e95d6df1430ab4e