### PR TITLE
Improve routing logic and UI display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,8 +69,8 @@ const RAW_LINES: Omit<LineDef,'color'>[] = [
   { id:'OMSK-NCH-IZH', name:'Омск → Набережные Челны (через Тюмень / Екатеринбург)', style:'dashed', segments: segmentsFromStations(route(['Омск','Тюмень','Екатеринбург','Набережные Челны']))},
   { id:'OMSK-NCH-IZH-GRAY', name:'Омск → Уфа (через Тюмень / Екатеринбург)', style:'solid', segments: segmentsFromStations(route(['Омск','Тюмень','Екатеринбург','Набережные Челны','Уфа']))},
   { id:'OMSK-NCH-UFA', name:'Омск → Набережные Челны (через Курган / Челябинск / Уфа)', style:'dotted', segments: segmentsFromStations(route(['Омск','Курган','Челябинск','Уфа','Набережные Челны']))},
-  { id:'OMSK-VVO-GREY', name:'Омск → Владивосток (серая)', style:'solid', segments: segmentsFromStations(route(['Омск','Кемерово','Красноярск','Иркутск','Улан-Удэ','Чита','Сковородино','Свободный','Благовещенск','Биробиджан','Хабаровск','Уссурийск','Владивосток']))},
-  { id:'OMSK-VVO-SALAD', name:'Омск → Владивосток (салатовая)', style:'solid', segments: segmentsFromStations(route(['Омск','Кемерово','Красноярск','Иркутск','Улан-Удэ','Чита','Сковородино','Свободный','Благовещенск','Биробиджан','Хабаровск','Уссурийск','Владивосток']))},
+  { id:'OMSK-VVO-GREY', name:'Омск → Владивосток (серая)', style:'solid', segments: segmentsFromStations(route(['Омск','Новосибирск','Кемерово','Красноярск','Иркутск','Улан-Удэ','Чита','Сковородино','Свободный','Благовещенск','Биробиджан','Хабаровск','Уссурийск','Владивосток']))},
+  { id:'OMSK-VVO-SALAD', name:'Омск → Владивосток (салатовая)', style:'solid', segments: segmentsFromStations(route(['Омск','Новосибирск','Кемерово','Красноярск','Иркутск','Улан-Удэ','Чита','Сковородино','Свободный','Благовещенск','Биробиджан','Хабаровск','Уссурийск','Владивосток']))},
   { id:'OMSK-VLG-GREY', name:'Омск → Волгоград (через Курган / Челябинск / Уфа / Тольятти / Саратов)', style:'solid', segments: segmentsFromStations(route(['Омск','Курган','Челябинск','Уфа','Тольятти','Саратов','Волгоград']))},
   // Тёмно-коричневый северный блок
   { id:'SRG-EKB', name:'Сургут → Екатеринбург (через Тюмень)', style:'solid', segments: segmentsFromStations(route(['Сургут','Тюмень','Екатеринбург']))},
@@ -158,6 +158,7 @@ const CORRIDORS: Corridor[] = [
   { id:'C_EAST_SALAD', name:'Москва → Владивосток (салатовый)', color:'#7ED957', lineIds:['MSK-NCH-SALAD','OMSK-NCH-IZH','OMSK-NCH-UFA','OMSK-VVO-SALAD'] },
   { id:'C_MSK_KRD', name:'Москва → Краснодар (оранжевый)', color:'#CC5500', lineIds:['MSK-RSTDN','RST-KRD'] },
   { id:'C_MSK_ORSK', name:'Москва → Орск (серый)', color:'#BDBDBD', lineIds:['MSK-ORSK'] },
+  { id:'C_MSK_SYK', name:'Москва → Сыктывкар', color:'#8B4513', lineIds:['SYK-KIR-YAR-MSK'] },
   { id:'C_SIB_SHORTS', name:'Сибирские ответвления (коричневый)', color:'#8B4513', lineIds:['NSK-GALT','TOM-NOVK','KRS-KYZ','CHT-MAG'] },
   { id:'C_VOLGA_BROWN', name:'Поволжье (коричневый)', color:'#8B4513', lineIds:['YOL-CHB-NNOV-VLA-MSK','MSK-VLA-NNOV-CHB-KZN-ULY-TLT'] },
   { id:'C_SOUTH_GREY', name:'Крым → Владивосток(фиолетовый)', color:'#7E57C2', lineIds:['VLG-RST-PURPLE','RST-MAR-CRIMEA-PINK','RST-KRD-PURPLE','KRD-CRIMEA-PINK','SRT-VRN-RST','OMSK-VVO-GREY','OMSK-VLG-GREY','OMSK-NCH-IZH-GRAY'] }
@@ -213,6 +214,69 @@ export default function MetroBranches(){
 
   const pathInfo = pathOptions[pathIndex] ?? { path: [], length: 0 };
   const pathEdges = useMemo(() => buildEdgesFromPath(pathInfo.path), [pathInfo.path]);
+  const pathSegments = useMemo(() => segmentsFromStations(pathInfo.path), [pathInfo.path]);
+  const findLineBySegment = useCallback((segId:string) => LINES.find(l=>l.segments.includes(segId)), []);
+  const routeDetails = useMemo(() => {
+    if(pathSegments.length===0) return [] as Array<{line:LineDef|undefined; stations:string[]}>;
+    const groups:Array<{line:LineDef|undefined; stations:string[]}> = [];
+    let currentLine = findLineBySegment(pathSegments[0]);
+    let currentStations = [pathInfo.path[0], pathInfo.path[1]];
+    for(let i=1;i<pathSegments.length;i++){
+      const line = findLineBySegment(pathSegments[i]);
+      const station = pathInfo.path[i+1];
+      if(line && currentLine && line.id===currentLine.id){
+        currentStations.push(station);
+      }else{
+        groups.push({line: currentLine, stations: currentStations});
+        currentLine = line;
+        currentStations = [pathInfo.path[i], station];
+      }
+    }
+    groups.push({line: currentLine, stations: currentStations});
+    return groups;
+  }, [pathSegments, pathInfo.path, findLineBySegment]);
+
+  const [animating, setAnimating] = useState(false);
+  const [animProgress, setAnimProgress] = useState(0);
+
+  const handleGo = useCallback(() => {
+    if(pathEdges.length===0) return;
+    setAnimating(true);
+    setAnimProgress(0);
+  }, [pathEdges]);
+
+  useEffect(()=>{
+    if(!animating) return;
+    const duration = 10000;
+    const start = performance.now();
+    let raf:number;
+    const step = (now:number)=>{
+      const t = Math.min((now-start)/duration,1);
+      setAnimProgress(t);
+      if(t<1) raf=requestAnimationFrame(step); else setAnimating(false);
+    };
+    raf=requestAnimationFrame(step);
+    return ()=>cancelAnimationFrame(raf);
+  },[animating]);
+
+  const vehiclePos = useMemo(()=>{
+    if(pathEdges.length===0) return null;
+    const total = pathEdges.reduce((s,e)=>{
+      const a=pos[e.a], b=pos[e.b];
+      return s+Math.hypot(a.x-b.x,a.y-b.y);
+    },0);
+    let d = total*animProgress;
+    for(const e of pathEdges){
+      const a=pos[e.a], b=pos[e.b];
+      const len=Math.hypot(a.x-b.x,a.y-b.y);
+      if(d<=len){
+        const t=d/len;
+        return {x:a.x+(b.x-a.x)*t, y:a.y+(b.y-a.y)*t};
+      }
+      d-=len;
+    }
+    return null;
+  },[animProgress,pathEdges,pos]);
 
   const containerWidth=1200, containerHeight=800;
 
@@ -260,30 +324,6 @@ export default function MetroBranches(){
 
       <div className="flex">
         <div className="w-80 bg-white border-r p-3 h-screen overflow-y-auto">
-          <div className="mb-4">
-            <h3 className="font-bold text-base mb-2 text-gray-800">Маршрут</h3>
-            <div className="space-y-2 text-sm">
-              <select value={startStation} onChange={e=>setStartStation(e.target.value)} className="w-full border p-1 rounded">
-                <option value="">Начальная станция</option>
-                {stations.map(s=>(<option key={s} value={s}>{s}</option>))}
-              </select>
-              <select value={endStation} onChange={e=>setEndStation(e.target.value)} className="w-full border p-1 rounded">
-                <option value="">Конечная станция</option>
-                {stations.map(s=>(<option key={s} value={s}>{s}</option>))}
-              </select>
-              {pathOptions.length>1 && (
-                <select value={pathIndex} onChange={e=>setPathIndex(Number(e.target.value))} className="w-full border p-1 rounded">
-                  {pathOptions.map((p,i)=>(<option key={i} value={i}>Вариант {i+1} ({Math.round(p.length)})</option>))}
-                </select>
-              )}
-              {pathInfo.path.length>1 && (
-                <div className="pt-1 space-y-1">
-                  <div>Протяжённость: {Math.round(pathInfo.length)}</div>
-                  <div className="text-xs text-gray-600 break-words">{pathInfo.path.join(' → ')}</div>
-                </div>
-              )}
-            </div>
-          </div>
           <h3 className="font-bold text-base mb-2 text-gray-800">Коридоры</h3>
           <LegendCorridors CORRIDORS={CORRIDORS} LINES={LINES} visible={visible} toggleCorridor={toggleCorridor} soloCorridor={soloCorridor} toggleLine={toggleLine} />
           <div className="mt-4 border-t pt-3 text-xs">
@@ -318,11 +358,59 @@ export default function MetroBranches(){
               {pathEdges.map((e,i)=>{
                 const a=pos[e.a], b=pos[e.b];
                 if(!a||!b) return null;
-                return <line key={`path_${i}`} x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="#000" strokeWidth={10} strokeLinecap="round" />;
+                return (
+                  <g key={`path_${i}`}>
+                    <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="#fff" strokeWidth={10} strokeLinecap="round" />
+                    <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="#000" strokeWidth={6} strokeLinecap="round" />
+                  </g>
+                );
               })}
+              {vehiclePos && (
+                <text x={vehiclePos.x} y={vehiclePos.y} fontSize={20} textAnchor="middle" dominantBaseline="middle">🚚</text>
+              )}
               <StationsAndLabels stations={stations} pos={pos} labels={labels} />
             </g>
           </svg>
+        </div>
+
+        <div className="w-80 bg-white border-l p-3 h-screen overflow-y-auto">
+          <h3 className="font-bold text-base mb-2 text-gray-800">Маршрут</h3>
+          <div className="space-y-2 text-sm">
+            <select value={startStation} onChange={e=>setStartStation(e.target.value)} className="w-full border p-1 rounded">
+              <option value="">Начальная станция</option>
+              {stations.map(s=>(<option key={s} value={s}>{s}</option>))}
+            </select>
+            <select value={endStation} onChange={e=>setEndStation(e.target.value)} className="w-full border p-1 rounded">
+              <option value="">Конечная станция</option>
+              {stations.map(s=>(<option key={s} value={s}>{s}</option>))}
+            </select>
+            {pathOptions.length>1 && (
+              <select value={pathIndex} onChange={e=>setPathIndex(Number(e.target.value))} className="w-full border p-1 rounded">
+                {pathOptions.map((p,i)=>(<option key={i} value={i}>Вариант {i+1} ({Math.round(p.length)})</option>))}
+              </select>
+            )}
+            {pathInfo.path.length>1 && (
+              <div className="pt-1 space-y-2">
+                <div className="font-medium">Протяжённость: {Math.round(pathInfo.length)}</div>
+                <div className="space-y-2">
+                  {routeDetails.map((g,i)=>(
+                    <div key={i} className="flex items-start gap-2 border rounded p-2">
+                      <div className="w-2 rounded" style={{background:g.line?.color}} />
+                      <div className="flex-1">
+                        <div className="font-medium">{g.stations[0]} → {g.stations[g.stations.length-1]}</div>
+                        {g.stations.length>2 && (
+                          <div className="text-xs text-gray-600">{g.stations.slice(1,-1).join(' → ')}</div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                {!animating && (
+                  <button onClick={handleGo} className="w-full bg-green-500 hover:bg-green-600 text-white rounded py-1">Поехали</button>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -148,6 +148,7 @@ export function findPaths(start: string, end: string, limit = 3): Array<{ path: 
   const graph = buildGraph();
   const results: Array<{path:string[]; length:number}> = [];
   const queue: Array<{path:string[]; length:number}> = [{ path:[start], length:0 }];
+  const best = new Map<string, number>();
 
   while(queue.length > 0 && results.length < limit){
     queue.sort((a,b)=>a.length-b.length);
@@ -160,7 +161,10 @@ export function findPaths(start: string, end: string, limit = 3): Array<{ path: 
     const neigh = graph.get(last) ?? [];
     for(const {to, weight} of neigh){
       if(cur.path.includes(to)) continue;
-      queue.push({ path:[...cur.path, to], length: cur.length + weight });
+      const newLen = cur.length + weight;
+      if(best.has(to) && best.get(to)! <= newLen) continue;
+      best.set(to, newLen);
+      queue.push({ path:[...cur.path, to], length: newLen });
     }
   }
 


### PR DESCRIPTION
## Summary
- add dedicated panel for route planning with color-coded segment breakdown
- highlight active path in contrasting color and animate a truck with "Поехали" button
- restore Moscow–Syktyvkar corridor in corridor list

## Testing
- `npm run build`
- `npx -y tsx test.ts` *(fails: Cannot find module '/workspace/DriveMetro/test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68b4f37a6af483218b053866a28df32b