### PR TITLE
Show multiple route options and loading truck animation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,15 @@
 html, body, #root {
   height: 100%;
 }
+
+@keyframes truck-drive {
+  0% { transform: translateX(-120px); }
+  100% { transform: translateX(1200px); }
+}
+
+.truck-drive {
+  position: absolute;
+  top: 50%;
+  left: -120px;
+  animation: truck-drive 4s linear infinite;
+}


### PR DESCRIPTION
## Summary
- display all suggested routes at once and allow toggling and selecting each
- animate a truck across the map while waiting for AI suggestions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7b6f200e48321bd6f106053fbc2c9