### PR TITLE
Add valid segment list to OpenRouter prompt

### DIFF
--- a/src/services/openrouter.ts
+++ b/src/services/openrouter.ts
@@ -60,6 +60,15 @@ function buildPrompt(start: string, end: string, lines: LineInfo[]): string {
   const intersectionsText = Array.from(intersections.entries())
     .map(([city, ids]) => `${city}: [${ids.join(", ")}]`)
     .join("\n");
+  const segmentsText = lines
+    .map(l => {
+      const edges: string[] = [];
+      for (let i = 0; i < l.stations.length - 1; i++) {
+        edges.push(`${l.stations[i]}-${l.stations[i + 1]}`);
+      }
+      return `${l.id}: ${edges.join(", ")}`;
+    })
+    .join("\n");
 
   const used = new Set<string>();
   lines.forEach(l => l.stations.forEach(s => used.add(s)));
@@ -79,7 +88,7 @@ function buildPrompt(start: string, end: string, lines: LineInfo[]): string {
     "2. Каждый маршрут строится только по соседним станциям ветки: нельзя перескакивать через города.",
     "3. Можно двигаться по веткам в любом направлении.",
     "4. Переход между ветками разрешён только в городах‑пересечениях.",
-    "5. Каждая пара {from,to} должна быть двумя последовательными станциями заявленной ветки.",
+    "5. Каждая пара {from,to} должна быть двумя последовательными станциями заявленной ветки и входить в список допустимых сегментов.",
     "6. Указывай ВСЕ промежуточные станции маршрута и не повторяй города в пределах одного маршрута.",
     `7. Маршрут обязан начинаться строго в "${start}" и заканчиваться строго в "${end}".`,
     "8. Для каждого перехода указывай ветку (branch), по которой он выполнен.",
@@ -99,6 +108,9 @@ function buildPrompt(start: string, end: string, lines: LineInfo[]): string {
     "",
     "ПЕРЕСЕЧЕНИЯ ВЕТОК:",
     intersectionsText,
+    "",
+    "ДОПУСТИМЫЕ СЕГМЕНТЫ ПО ВЕТКАМ (используй только их):",
+    segmentsText,
     "",
     "Верни только JSON без пояснений.",
   ].join("\n");


### PR DESCRIPTION
## Summary
- Generate explicit branch segments and include them in AI prompt
- Enforce that each {from,to} pair must match listed segments
- Append "Valid Segments by Branch" section to prompt text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node --loader ts-node/esm --experimental-specifier-resolution=node test.ts` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68b7c5defb808321982d9f0f412d4f8e