### PR TITLE
Handle empty touch lists in touch events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -397,17 +397,22 @@ export default function MetroBranches(){
   const handleMouseDown = useCallback((e:React.MouseEvent)=>{ setIsDragging(true); setLastMouse({x:e.clientX,y:e.clientY}); },[]);
   const handleMouseMove = useCallback((e:React.MouseEvent)=>{ if(!isDragging) return; const dx=e.clientX-lastMouse.x; const dy=e.clientY-lastMouse.y; setTranslateX(p=>p+dx); setTranslateY(p=>p+dy); setLastMouse({x:e.clientX,y:e.clientY}); },[isDragging,lastMouse]);
   const handleMouseUp = useCallback(()=>{ setIsDragging(false); },[]);
-  const handleTouchStart = useCallback((e:TouchEvent)=>{ setIsDragging(true); const t=e.touches[0]; setLastMouse({x:t.clientX,y:t.clientY}); },[]);
+  const handleTouchStart = useCallback((e:TouchEvent)=>{
+    if (e.touches.length === 0) return;
+    setIsDragging(true);
+    const t = e.touches[0];
+    setLastMouse({ x: t.clientX, y: t.clientY });
+  }, []);
   const handleTouchMove = useCallback((e:TouchEvent)=>{
-    if(!isDragging) return;
-    if(e.cancelable) e.preventDefault();
-    const t=e.touches[0];
-    const dx=t.clientX-lastMouse.x;
-    const dy=t.clientY-lastMouse.y;
-    setTranslateX(p=>p+dx);
-    setTranslateY(p=>p+dy);
-    setLastMouse({x:t.clientX,y:t.clientY});
-  },[isDragging,lastMouse]);
+    if (!isDragging || e.touches.length === 0) return;
+    if (e.cancelable) e.preventDefault();
+    const t = e.touches[0];
+    const dx = t.clientX - lastMouse.x;
+    const dy = t.clientY - lastMouse.y;
+    setTranslateX(p => p + dx);
+    setTranslateY(p => p + dy);
+    setLastMouse({ x: t.clientX, y: t.clientY });
+  }, [isDragging, lastMouse]);
   const handleTouchEnd = useCallback(()=>{ setIsDragging(false); },[]);
   useEffect(()=>{ const el=svgRef.current; if(!el) return; el.addEventListener('touchstart',handleTouchStart,{passive:false}); el.addEventListener('touchmove',handleTouchMove,{passive:false}); el.addEventListener('touchend',handleTouchEnd,{passive:false}); el.addEventListener('touchcancel',handleTouchEnd,{passive:false}); return ()=>{ el.removeEventListener('touchstart',handleTouchStart); el.removeEventListener('touchmove',handleTouchMove); el.removeEventListener('touchend',handleTouchEnd); el.removeEventListener('touchcancel',handleTouchEnd); }; },[handleTouchStart,handleTouchMove,handleTouchEnd]);
   const resetView = useCallback(()=>{ setScale(0.6); setTranslateX(300); setTranslateY(150); },[]);


### PR DESCRIPTION
## Summary
- Guard touch start from empty touch arrays
- Exit touch move when dragging isn't active or no touch points

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7ceb1d4588321ace42f8ac24164ac